### PR TITLE
docs(readme): add section on interview process

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -22,6 +22,20 @@ Interested in changing the future of creator marketing with us? Passionate about
 
 We are growing quickly and we are always interested in meeting new talent. Check out our [Careers Page](https://hashtagpaid.com/company#careers?utm_source=github.com&utm_medium=referral&utm_campaign=org-page) for all current opportunities.
 
+### 🤝 Our interview process
+
+Two rounds of interviews across two days with four different components.
+
+- Hiring Manager Interview (60 mins). We want to learn more about your experience and interests at this stage. You will also learn about the engineering team and decide if #paid is the right fit for you.
+
+- Meet the team (60 mins). You will meet Product, Design and Engineering team members to learn how you collaborate across these disciplines. You will also have an opportunity to ask about our team structure and culture.
+
+- Project Deep Dive (60 mins). You will meet the architecture team and talk in-depth about a past project or codebase you loved (or hated!). Come prepared to talk about technical topics (architecture, trade-offs and tools) and non-technical details (team structure, project planning, lessons learned and overall business impact). You are welcome to present slides or a codebase, but remember that this interview is a conversation, not a presentation.
+
+- VP interview (30 mins). Intended to cover your skills in collaboration and communication, as well as to provide a final opportunity for you to ask any lingering questions about the company strategy.
+
+Note: this is an outline of interviewing at #paid. The interview process may vary depending on your experience.
+
 ### 👀 Check us out
 
 - [#paid on LinkedIn](https://www.linkedin.com/company/hashtagpaid)


### PR DESCRIPTION
### Description

I'm using this readme when cold sourcing candidates. I'd like to add the interview process here while we don't have a public JD.